### PR TITLE
pc - add test coverage for ApiController base class

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/controllers/ApiControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ApiControllerTests.java
@@ -1,0 +1,62 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@WebMvcTest(controllers = DummyController.class)
+@Import(TestConfig.class)
+public class ApiControllerTests extends ControllerTestCase {
+
+        @MockBean
+        UserRepository userRepository;
+
+        @Test
+        public void generic_message_test() {
+                ApiController apiController = new DummyController();
+                Object result = apiController.genericMessage("Hello World");
+                Object expected = Map.of("message", "Hello World");
+                assertEquals(expected,result);
+        }       
+
+        @Test
+        public void test_that_dummy_controller_returns_String1_when_1_is_passed() throws Exception {
+
+                // act
+                MvcResult response = mockMvc.perform(get("/dummycontroller?id=1"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                assertEquals("String1", response.getResponse().getContentAsString());
+        }
+
+        @Test
+        public void test_that_dummy_controller_returns_Exception_when_1_is_not_passed() throws Exception {
+
+                // act
+                MvcResult response = mockMvc.perform(get("/dummycontroller?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("String with id 7 not found", json.get("message"));
+        }
+
+}
+

--- a/src/test/java/edu/ucsb/cs156/example/controllers/DummyController.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/DummyController.java
@@ -1,0 +1,26 @@
+package edu.ucsb.cs156.example.controllers;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+
+
+/**
+ * This class is used to test ApiController and EntityNotFoundException
+ */
+
+@RequestMapping("/dummycontroller")
+@RestController
+public class DummyController extends ApiController {
+
+    @GetMapping("")
+    public String getById(@RequestParam Long id) throws EntityNotFoundException {
+        if (id == 1) {
+            return "String1";
+        }
+        throw new EntityNotFoundException(String.class, id);
+    }
+}


### PR DESCRIPTION
Closes #2 

In this PR, we add tests for the methods in the ApiController base class, and the exception handlers.

Without this, if you remove the example controllers, you lose test coverage for these methods.  