### PR TITLE
pc - add sync job capability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.4</version>
+    <version>3.4.2</version>
   </parent>
 
   <!-- (2) <groupId/> -->

--- a/src/main/java/edu/ucsb/cs156/example/ExampleApplication.java
+++ b/src/main/java/edu/ucsb/cs156/example/ExampleApplication.java
@@ -6,6 +6,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import edu.ucsb.cs156.example.services.wiremock.WiremockService;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +17,8 @@ import lombok.extern.slf4j.Slf4j;
  */
 @SpringBootApplication
 @Slf4j
+@EnableAsync // for @Async annotation for JobsService
+@EnableScheduling // for @Scheduled annotation for JobsService
 public class ExampleApplication {
 
   @Autowired

--- a/src/main/java/edu/ucsb/cs156/example/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/JobsController.java
@@ -90,7 +90,7 @@ public class JobsController extends ApiController {
   @GetMapping("/logs/{id}")
   public String getJobLogs(@Parameter(name = "id", description = "Job ID") @PathVariable Long id) {
 
-    return jobService.getLongJob(id);
+    return jobService.getJobLogs(id);
   }
 
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/JobsController.java
@@ -1,0 +1,97 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.example.entities.Job;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.jobs.TestJob;
+import edu.ucsb.cs156.example.repositories.JobsRepository;
+import edu.ucsb.cs156.example.services.jobs.JobService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Jobs")
+@RequestMapping("/api/jobs")
+@RestController
+@Slf4j
+public class JobsController extends ApiController {
+  @Autowired private JobsRepository jobsRepository;
+
+  @Autowired private JobService jobService;
+
+  @Autowired ObjectMapper mapper;
+
+  @Operation(summary = "List all jobs")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @GetMapping("/all")
+  public Iterable<Job> allJobs() {
+    Iterable<Job> jobs = jobsRepository.findAll();
+    return jobs;
+  }
+
+  @Operation(summary = "Delete all job records")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("/all")
+  public Map<String, String> deleteAllJobs() {
+    jobsRepository.deleteAll();
+    return Map.of("message", "All jobs deleted");
+  }
+
+  @Operation(summary = "Get a specific Job Log by ID if it is in the database")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @GetMapping("")
+  public Job getJobLogById(
+      @Parameter(name = "id", description = "ID of the job") @RequestParam Long id)
+      throws JsonProcessingException {
+
+    Job job =
+        jobsRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(Job.class, id));
+
+    return job;
+  }
+
+  @Operation(summary = "Delete specific job record")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Map<String, String> deleteAllJobs(@Parameter(name = "id") @RequestParam Long id) {
+    if (!jobsRepository.existsById(id)) {
+      return Map.of("message", String.format("Job with id %d not found", id));
+    }
+    jobsRepository.deleteById(id);
+    return Map.of("message", String.format("Job with id %d deleted", id));
+  }
+
+  @Operation(summary = "Launch Test Job (click fail if you want to test exception handling)")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/launch/testjob")
+  public Job launchTestJob(
+      @Parameter(name = "fail") @RequestParam Boolean fail,
+      @Parameter(name = "sleepMs") @RequestParam Integer sleepMs) {
+
+    TestJob testJob = TestJob.builder().fail(fail).sleepMs(sleepMs).build();
+    return jobService.runAsJob(testJob);
+  }
+
+
+  @Operation(summary = "Get long job logs")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @GetMapping("/logs/{id}")
+  public String getJobLogs(@Parameter(name = "id", description = "Job ID") @PathVariable Long id) {
+
+    return jobService.getLongJob(id);
+  }
+
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/Job.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Job.java
@@ -1,0 +1,38 @@
+package edu.ucsb.cs156.example.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import java.time.ZonedDateTime;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Entity(name = "jobs")
+@EntityListeners(AuditingEntityListener.class)
+public class Job {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  @JsonIgnore
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "created_by_id")
+  private User createdBy;
+
+  @CreatedDate private ZonedDateTime createdAt;
+  @LastModifiedDate private ZonedDateTime updatedAt;
+
+  private String status;
+
+  // 1048576 is 2^20, which is the max size of a mediumtext in MySQL
+  @Column(
+      columnDefinition = "TEXT",
+      length = 1048576) // needed for long strings, i.e. log entries longer than 255
+  // characters
+  private String log;
+}

--- a/src/main/java/edu/ucsb/cs156/example/jobs/TestJob.java
+++ b/src/main/java/edu/ucsb/cs156/example/jobs/TestJob.java
@@ -1,0 +1,27 @@
+package edu.ucsb.cs156.example.jobs;
+
+import edu.ucsb.cs156.example.services.jobs.JobContext;
+import edu.ucsb.cs156.example.services.jobs.JobContextConsumer;
+import lombok.Builder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Builder
+public class TestJob implements JobContextConsumer {
+
+  private boolean fail;
+  private int sleepMs;
+
+  @Override
+  public void accept(JobContext ctx) throws Exception {
+    // Ensure this is not null
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    ctx.log("Hello World! from test job!");
+    Thread.sleep(sleepMs);
+    if (fail) {
+      throw new Exception("Fail!");
+    }
+    ctx.log("Goodbye from test job!");
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/JobsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/JobsRepository.java
@@ -1,0 +1,8 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.Job;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JobsRepository extends CrudRepository<Job, Long> {}

--- a/src/main/java/edu/ucsb/cs156/example/services/jobs/JobContext.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/jobs/JobContext.java
@@ -1,0 +1,20 @@
+package edu.ucsb.cs156.example.services.jobs;
+
+import edu.ucsb.cs156.example.entities.Job;
+import edu.ucsb.cs156.example.repositories.JobsRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@AllArgsConstructor
+@Slf4j
+public class JobContext {
+  private JobsRepository jobsRepository;
+  private Job job;
+
+  public void log(String message) {
+    log.info("Job %s: %s".formatted(job.getId(), message));
+    String previousLog = job.getLog() == null ? "" : (job.getLog() + "\n");
+    job.setLog(previousLog + message);
+    if (jobsRepository != null) jobsRepository.save(job);
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/services/jobs/JobContextConsumer.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/jobs/JobContextConsumer.java
@@ -1,0 +1,6 @@
+package edu.ucsb.cs156.example.services.jobs;
+
+@FunctionalInterface
+public interface JobContextConsumer {
+  void accept(JobContext c) throws Exception;
+}

--- a/src/main/java/edu/ucsb/cs156/example/services/jobs/JobService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/jobs/JobService.java
@@ -41,7 +41,7 @@ public class JobService {
     jobsRepository.save(job);
   }
 
-  public String getLongJob(Long jobId) {
+  public String getJobLogs(Long jobId) {
     Job job =
         jobsRepository
             .findById(jobId)

--- a/src/main/java/edu/ucsb/cs156/example/services/jobs/JobService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/jobs/JobService.java
@@ -1,0 +1,53 @@
+package edu.ucsb.cs156.example.services.jobs;
+
+import edu.ucsb.cs156.example.entities.Job;
+import edu.ucsb.cs156.example.repositories.JobsRepository;
+import edu.ucsb.cs156.example.services.CurrentUserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JobService {
+  @Autowired private JobsRepository jobsRepository;
+
+  @Autowired private CurrentUserService currentUserService;
+
+  @Lazy @Autowired private JobService self;
+
+  public Job runAsJob(JobContextConsumer jobFunction) {
+    Job job = Job.builder().createdBy(currentUserService.getUser()).status("running").build();
+
+    jobsRepository.save(job);
+    self.runJobAsync(job, jobFunction);
+
+    return job;
+  }
+
+  @Async
+  public void runJobAsync(Job job, JobContextConsumer jobFunction) {
+    JobContext context = new JobContext(jobsRepository, job);
+
+    try {
+      jobFunction.accept(context);
+    } catch (Exception e) {
+      job.setStatus("error");
+      context.log(e.getMessage());
+      return;
+    }
+
+    job.setStatus("complete");
+    jobsRepository.save(job);
+  }
+
+  public String getLongJob(Long jobId) {
+    Job job =
+        jobsRepository
+            .findById(jobId)
+            .orElseThrow(() -> new IllegalArgumentException("Job not found"));
+
+    String log = job.getLog();
+    return log != null ? log : "";
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/JobsControllerTests.java
@@ -1,0 +1,327 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.Job;
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.repositories.JobsRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.jobs.JobService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@Slf4j
+@WebMvcTest(controllers = JobsController.class)
+@Import(JobService.class)
+@AutoConfigureDataJpa
+public class JobsControllerTests extends ControllerTestCase {
+
+  @MockitoBean JobsRepository jobsRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  @Autowired JobService jobService;
+
+  @Autowired ObjectMapper objectMapper;
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_can_get_all_jobs() throws Exception {
+
+    // arrange
+
+    Job job1 = Job.builder().log("this is job 1").build();
+    Job job2 = Job.builder().log("this is job 2").build();
+
+    ArrayList<Job> expectedJobs = new ArrayList<>();
+    expectedJobs.addAll(Arrays.asList(job1, job2));
+
+    when(jobsRepository.findAll()).thenReturn(expectedJobs);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/jobs/all")).andExpect(status().isOk()).andReturn();
+
+    // assert
+
+    verify(jobsRepository, atLeastOnce()).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedJobs);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void api_getJobLogById__admin_logged_in__returns_job_by_id() throws Exception {
+
+    // arrange
+
+    Job job = Job.builder().id(1L).status("completed").log("This is a test job log.").build();
+
+    when(jobsRepository.findById(eq(1L))).thenReturn(Optional.of(job));
+
+    // act
+
+    MvcResult response =
+        mockMvc.perform(get("/api/jobs?id=1")).andExpect(status().isOk()).andReturn();
+
+    // assert
+
+    verify(jobsRepository, times(1)).findById(1L);
+    String expectedJson = mapper.writeValueAsString(job);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void api_getJobLogById__admin_logged_in__returns_not_found_for_missing_job()
+      throws Exception {
+
+    // arrange
+
+    when(jobsRepository.findById(eq(2L))).thenReturn(Optional.empty());
+
+    // act
+
+    MvcResult response =
+        mockMvc.perform(get("/api/jobs?id=2")).andExpect(status().isNotFound()).andReturn();
+
+    // assert
+
+    verify(jobsRepository, times(1)).findById(2L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("Job with id 2 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_can_delete_all_jobs() throws Exception {
+
+    doNothing().when(jobsRepository).deleteAll();
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/jobs/all").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(jobsRepository, times(1)).deleteAll();
+    String expectedJson = mapper.writeValueAsString(Map.of("message", "All jobs deleted"));
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void test_getJobLogs_admin_can_get_job_log() throws Exception {
+    // Arrange
+    Long jobId = 1L;
+    String jobLog = "This is a job log";
+    Job job = Job.builder().build();
+    job.setLog(jobLog);
+    when(jobsRepository.findById(jobId)).thenReturn(Optional.of(job));
+
+    // Act & Assert
+    mockMvc
+        .perform(get("/api/jobs/logs/{id}", jobId))
+        .andExpect(status().isOk())
+        .andExpect(content().string(jobLog));
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void test_getJobLogs_admin_can_get_empty_log() throws Exception {
+    // Arrange
+    Long jobId = 2L;
+    Job job = Job.builder().build();
+    job.setLog("");
+    when(jobsRepository.findById(jobId)).thenReturn(Optional.of(job));
+
+    // Act & Assert
+    mockMvc
+        .perform(get("/api/jobs/logs/{id}", jobId))
+        .andExpect(status().isOk())
+        .andExpect(content().string(""));
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_can_delete_specific_job() throws Exception {
+
+    // arrange
+
+    when(jobsRepository.existsById(eq(1L))).thenReturn(true);
+    doNothing().when(jobsRepository).deleteById(eq(1L));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/jobs?id=1").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(jobsRepository, times(1)).deleteById(eq(1L));
+    String expectedJson = mapper.writeValueAsString(Map.of("message", "Job with id 1 deleted"));
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_gets_reasonable_error_when_deleting_non_existing_job() throws Exception {
+
+    // arrange
+
+    when(jobsRepository.existsById(eq(2L))).thenReturn(false);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/jobs?id=2").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(jobsRepository, times(1)).existsById(eq(2L));
+    String expectedJson = mapper.writeValueAsString(Map.of("message", "Job with id 2 not found"));
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_can_launch_test_job() throws Exception {
+
+    // arrange
+
+    User user = currentUserService.getUser();
+
+    Job jobStarted =
+        Job.builder()
+            .id(0L)
+            .createdBy(user)
+            .createdAt(null)
+            .updatedAt(null)
+            .status("running")
+            .log("Hello World! from test job!")
+            .build();
+
+    Job jobCompleted =
+        Job.builder()
+            .id(0L)
+            .createdBy(user)
+            .createdAt(null)
+            .updatedAt(null)
+            .status("complete")
+            .log("Hello World! from test job!\nGoodbye from test job!")
+            .build();
+
+    when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobCompleted);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=2000").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    String responseString = response.getResponse().getContentAsString();
+    Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+    assertEquals("running", jobReturned.getStatus());
+
+    await()
+        .atMost(1, SECONDS)
+        .untilAsserted(() -> verify(jobsRepository, times(2)).save(eq(jobStarted)));
+    await()
+        .atMost(10, SECONDS)
+        .untilAsserted(() -> verify(jobsRepository, times(4)).save(eq(jobCompleted)));
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_can_launch_test_job_that_fails() throws Exception {
+
+    // arrange
+
+    User user = currentUserService.getUser();
+
+    Job jobStarted =
+        Job.builder()
+            .id(0L)
+            .createdBy(user)
+            .createdAt(null)
+            .updatedAt(null)
+            .status("running")
+            .log("Hello World! from test job!")
+            .build();
+
+    Job jobFailed =
+        Job.builder()
+            .id(0L)
+            .createdBy(user)
+            .createdAt(null)
+            .updatedAt(null)
+            .status("error")
+            .log("Hello World! from test job!\nFail!")
+            .build();
+
+    when(jobsRepository.save(any(Job.class))).thenReturn(jobStarted).thenReturn(jobFailed);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=4000").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+    Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+    assertEquals("running", jobReturned.getStatus());
+
+    await()
+        .atMost(1, SECONDS)
+        .untilAsserted(() -> verify(jobsRepository, times(2)).save(eq(jobStarted)));
+
+    await()
+        .atMost(10, SECONDS)
+        .untilAsserted(() -> verify(jobsRepository, times(3)).save(eq(jobFailed)));
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/example/services/JobLogsServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/JobLogsServiceTests.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
-public class LongJobServiceTests {
+public class JobLogsServiceTests {
 
   @Mock private JobsRepository jobRepository;
 
@@ -24,23 +24,22 @@ public class LongJobServiceTests {
   }
 
   @Test
-  void test_getLongJob_with_log() {
+  void test_getJobLogs_with_log() {
     // Arrange
     Long jobId = 1L;
     Job job = Job.builder().build();
-    // JobContext ctx = new JobContext(null, job);
     job.setLog("This is a job log");
     when(jobRepository.findById(jobId)).thenReturn(Optional.of(job));
 
     // Act
-    String result = jobService.getLongJob(jobId);
+    String result = jobService.getJobLogs(jobId);
 
     // Assert
     assertEquals("This is a job log", result);
   }
 
   @Test
-  void test_getLongJob_with_null_log() {
+  void test_getJobLogs_with_null_log() {
     // Arrange
     Long jobId = 2L;
     Job job = Job.builder().build();
@@ -48,19 +47,19 @@ public class LongJobServiceTests {
     when(jobRepository.findById(jobId)).thenReturn(Optional.of(job));
 
     // Act
-    String result = jobService.getLongJob(jobId);
+    String result = jobService.getJobLogs(jobId);
 
     // Assert
     assertEquals("", result);
   }
 
   @Test
-  void test_getLongJob_job_not_found() {
+  void test_getJobLogs_job_not_found() {
     // Arrange
     Long jobId = 3L;
     when(jobRepository.findById(jobId)).thenReturn(Optional.empty());
 
     // Act & Assert
-    assertThrows(IllegalArgumentException.class, () -> jobService.getLongJob(jobId));
+    assertThrows(IllegalArgumentException.class, () -> jobService.getJobLogs(jobId));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/services/LongJobServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/LongJobServiceTests.java
@@ -1,0 +1,66 @@
+package edu.ucsb.cs156.example.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import edu.ucsb.cs156.example.entities.Job;
+import edu.ucsb.cs156.example.repositories.JobsRepository;
+import edu.ucsb.cs156.example.services.jobs.JobService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+public class LongJobServiceTests {
+
+  @Mock private JobsRepository jobRepository;
+
+  @InjectMocks private JobService jobService;
+
+  @BeforeEach
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void test_getLongJob_with_log() {
+    // Arrange
+    Long jobId = 1L;
+    Job job = Job.builder().build();
+    // JobContext ctx = new JobContext(null, job);
+    job.setLog("This is a job log");
+    when(jobRepository.findById(jobId)).thenReturn(Optional.of(job));
+
+    // Act
+    String result = jobService.getLongJob(jobId);
+
+    // Assert
+    assertEquals("This is a job log", result);
+  }
+
+  @Test
+  void test_getLongJob_with_null_log() {
+    // Arrange
+    Long jobId = 2L;
+    Job job = Job.builder().build();
+    job.setLog(null);
+    when(jobRepository.findById(jobId)).thenReturn(Optional.of(job));
+
+    // Act
+    String result = jobService.getLongJob(jobId);
+
+    // Assert
+    assertEquals("", result);
+  }
+
+  @Test
+  void test_getLongJob_job_not_found() {
+    // Arrange
+    Long jobId = 3L;
+    when(jobRepository.findById(jobId)).thenReturn(Optional.empty());
+
+    // Act & Assert
+    assertThrows(IllegalArgumentException.class, () -> jobService.getLongJob(jobId));
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/services/jobs/JobContextTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/jobs/JobContextTests.java
@@ -1,0 +1,24 @@
+package edu.ucsb.cs156.example.services.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import edu.ucsb.cs156.example.entities.Job;
+import org.junit.jupiter.api.Test;
+
+
+public class JobContextTests {
+  @Test
+  public void when_jobs_repository_is_null_does_not_save() throws Exception {
+
+    // arrange
+
+    Job job1 = Job.builder().build();
+    JobContext ctx = new JobContext(null, job1);
+
+    // act
+    ctx.log("This is a log message");
+
+    // assert
+    assertEquals("This is a log message", job1.getLog());
+  }
+
+}


### PR DESCRIPTION
In this PR, we add an async jobs capability similar to the one in proj-courses and proj-happycows.

This allows us to write jobs that are run in the background on demand, or are scheduled to run at the same time every day or week (based on a crontab like syntax.)