### PR TITLE
pc - bump spring-boot-starter to 3.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.4</version>
+    <version>3.4.2</version>
   </parent>
 
   <!-- (2) <groupId/> -->


### PR DESCRIPTION
In this PR we bump the spring boot starter to the latest current version, 3.4.2