### PR TITLE
sk - Add repeated deploy steps to Github Actions that deploy to gh-pages

### DIFF
--- a/.github/workflows/01-gh-pages-pr-table.yml
+++ b/.github/workflows/01-gh-pages-pr-table.yml
@@ -75,8 +75,12 @@ jobs:
         cp -r frontend/docs-index/* site
   
     - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: Wandalen/wretry.action@master
       with:
-        folder: site # The folder the action should deploy.
-        branch: gh-pages
-        clean: false # Automatically remove deleted files from the deploy branch
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          folder: site # The folder the action should deploy.
+          branch: gh-pages
+          clean: false

--- a/.github/workflows/04-gh-pages-redeploy-part-2.yml
+++ b/.github/workflows/04-gh-pages-redeploy-part-2.yml
@@ -73,11 +73,16 @@ jobs:
         cp -r frontend/docs-index/* site
         
     - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        folder: site # The folder the action should deploy.
-        branch: gh-pages
-        clean: true # Automatically remove deleted files from the deploy branch
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with:
+          folder: site # The folder the action should deploy.
+          branch: gh-pages
+          clean: true # Automatically remove deleted files from the deploy branch
 
   deploy-main-docs:
     name: Deploy Documentation for main branch

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -52,12 +52,17 @@ jobs:
         echo "prefix=${prefix}" >> "$GITHUB_ENV"
     
     - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: target/site/jacoco # The folder where mvn puts the files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: ${{env.prefix}}jacoco # The folder that we serve our files from
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: target/site/jacoco # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: ${{env.prefix}}jacoco # The folder that we serve our files from
 
 
   

--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -92,9 +92,13 @@ jobs:
 
     - name: Deploy 🚀
       if: always() # always upload artifacts, even if tests fail
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: target/pit-reports # The folder where the files we want to publish are located
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: ${{env.prefix}}pitest # The folder that we serve our files from
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: target/pit-reports # The folder where the files we want to publish are located
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: ${{env.prefix}}pitest # The folder that we serve our files from

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -81,9 +81,13 @@ jobs:
 
     - name: Deploy 🚀
       if: always() # always upload artifacts, even if tests fail
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: target/pit-reports # The folder where the files we want to publish are located
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: ${{env.prefix}}pitest # The folder that we serve our files from
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: target/pit-reports # The folder where the files we want to publish are located
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: ${{env.prefix}}pitest # The folder that we serve our files from

--- a/.github/workflows/32-frontend-coverage.yml
+++ b/.github/workflows/32-frontend-coverage.yml
@@ -64,12 +64,16 @@ jobs:
       
       - name: Deploy 🚀
         if: always() # always upload artifacts, even if tests fail
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: Wandalen/wretry.action@master
         with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: frontend/coverage/lcov-report # The folder where the javadoc files are located
-          clean: true # Automatically remove deleted files from the deploy branch
-          target-folder: ${{env.prefix}}coverage # The folder that we serve our javadoc files from
+          action: JamesIves/github-pages-deploy-action@v4
+          attempt_limit: 3
+          attempt_delay: 5000
+          with: |
+            branch: gh-pages # The branch the action should deploy to.
+            folder: frontend/coverage/lcov-report # The folder where the javadoc files are located
+            clean: true # Automatically remove deleted files from the deploy branch
+            target-folder: ${{env.prefix}}coverage # The folder that we serve our javadoc files from
 
 
   

--- a/.github/workflows/33-frontend-pr-mutation-testing.yml
+++ b/.github/workflows/33-frontend-pr-mutation-testing.yml
@@ -89,9 +89,13 @@ jobs:
       
       - name: Deploy 🚀
         if: always() # always upload artifacts, even if tests fail
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: Wandalen/wretry.action@master
         with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: frontend/reports/mutation # The folder where the javadoc files are located
-          clean: true # Automatically remove deleted files from the deploy branch
-          target-folder: ${{env.prefix}}/stryker # The folder that we serve our javadoc files from
+          action: JamesIves/github-pages-deploy-action@v4
+          attempt_limit: 3
+          attempt_delay: 5000
+          with: |
+            branch: gh-pages # The branch the action should deploy to.
+            folder: frontend/reports/mutation # The folder where the javadoc files are located
+            clean: true # Automatically remove deleted files from the deploy branch
+            target-folder: ${{env.prefix}}/stryker # The folder that we serve our javadoc files from

--- a/.github/workflows/34-frontend-main-mutation-testing.yml
+++ b/.github/workflows/34-frontend-main-mutation-testing.yml
@@ -58,9 +58,13 @@ jobs:
   
       - name: Deploy 🚀
         if: always() # always upload artifacts, even if tests fail
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: Wandalen/wretry.action@master
         with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: frontend/reports/mutation # The folder where the javadoc files are located
-          clean: true # Automatically remove deleted files from the deploy branch
-          target-folder: stryker # The folder that we serve our javadoc files from
+          action: JamesIves/github-pages-deploy-action@v4
+          attempt_limit: 3
+          attempt_delay: 5000
+          with: |
+            branch: gh-pages # The branch the action should deploy to.
+            folder: frontend/reports/mutation # The folder where the javadoc files are located
+            clean: true # Automatically remove deleted files from the deploy branch
+            target-folder: stryker # The folder that we serve our javadoc files from

--- a/.github/workflows/53-chromatic-main-branch.yml
+++ b/.github/workflows/53-chromatic-main-branch.yml
@@ -57,12 +57,17 @@ jobs:
           echo "<meta http-equiv=refresh content=0;url=${{steps.run_chromatic.outputs.storybookUrl}}>" > chromatic_static/index.html
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+        if: always() # always upload artifacts, even if tests fail
+        uses: Wandalen/wretry.action@master
         with:
-            branch: gh-pages # The branch the action should deploy to.
-            folder: frontend/chromatic_static # source
-            clean: true # Automatically remove deleted files from the deploy branch
-            target-folder: chromatic # destination 
-       
-     
+          action: JamesIves/github-pages-deploy-action@v4
+          attempt_limit: 3
+          attempt_delay: 5000
+          with: |
+              branch: gh-pages # The branch the action should deploy to.
+              folder: frontend/chromatic_static # source
+              clean: true # Automatically remove deleted files from the deploy branch
+              target-folder: chromatic # destination 
+        
+      
    

--- a/.github/workflows/55-chromatic-pr.yml
+++ b/.github/workflows/55-chromatic-pr.yml
@@ -95,13 +95,19 @@ jobs:
           mkdir -p chromatic_static_${{ needs.get-pr-num.outputs.pr_number }}
           echo "<meta http-equiv=refresh content=0;url=${{steps.run_chromatic.outputs.storybookUrl}}>" > chromatic_static_${{ needs.get-pr-num.outputs.pr_number }}/index.html
           echo "<meta http-equiv=refresh content=0;url=${{steps.run_chromatic.outputs.url}}>" > chromatic_static_${{ needs.get-pr-num.outputs.pr_number }}/build.html
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: Deploy 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: frontend/chromatic_static_${{ needs.get-pr-num.outputs.pr_number }} # The folder that the build-chromatic script generates files.
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: prs/${{ needs.get-pr-num.outputs.pr_number }}/chromatic # The folder that we serve our chromatic files from 
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |        
+          branch: gh-pages # The branch the action should deploy to.
+          folder: frontend/chromatic_static_${{ needs.get-pr-num.outputs.pr_number }} # The folder that the build-chromatic script generates files.
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: prs/${{ needs.get-pr-num.outputs.pr_number }}/chromatic # The folder that we serve our chromatic files from 
+  
   
   
  

--- a/.github/workflows/56-javadoc-main-branch.yml
+++ b/.github/workflows/56-javadoc-main-branch.yml
@@ -32,12 +32,15 @@ jobs:
     - name: Build javadoc
       run: mvn -DskipTests javadoc:javadoc
 
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: Deploy 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: target/site/apidocs # The folder where the javadoc files are located
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: javadoc # The folder that we serve our javadoc files from
-
-  
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |        
+          branch: gh-pages # The branch the action should deploy to.
+          folder: target/site/apidocs # The folder where mvn javadoc:javadoc outputs the javadoc files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: prs/${{ needs.get-pr-num.outputs.pr_number }}/javadoc # The folder that we serve our javadoc files from 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,6 +42,7 @@
         "@stryker-mutator/jest-runner": "^8.5.0",
         "@testing-library/react": "^16.0.0",
         "axios-mock-adapter": "^2.0.0",
+        "chromatic": "^11.25.2",
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.35.0",
         "eslint-plugin-storybook": "^0.8.0",
@@ -10775,9 +10776,10 @@
       }
     },
     "node_modules/chromatic": {
-      "version": "11.7.1",
+      "version": "11.25.2",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-11.25.2.tgz",
+      "integrity": "sha512-/9eQWn6BU1iFsop86t8Au21IksTRxwXAl7if8YHD05L2AbuMjClLWZo5cZojqrJHGKDhTqfrC2X2xE4uSm0iKw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "chroma": "dist/bin.js",
         "chromatic": "dist/bin.js",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,6 +63,7 @@
     "@stryker-mutator/jest-runner": "^8.5.0",
     "@testing-library/react": "^16.0.0",
     "axios-mock-adapter": "^2.0.0",
+    "chromatic": "^11.25.2",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-storybook": "^0.8.0",


### PR DESCRIPTION
In this PR, we modify all the Github Actions scripts that deploy to github pages to have a repeated deploy step. They will attempt to deploy at most 3 times if there are failures with a delay of 5000ms. 

They follow the format of this script in the Courses repo: https://github.com/ucsb-cs156/proj-courses/commit/bec86701b5447218ab5ac39697a5702d6b73de16

This will minimize the manual labor of re-running the action(s) when they fail as a false alarm because of contention over gh-pages branch.

Closes #5. 