### PR TITLE
sk - fix optional chaining mutation in currentUser

### DIFF
--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -226,23 +226,15 @@ describe("utils/currentUser tests", () => {
     test("hasRole falls back correctly with various data missing", async () => {
       expect(hasRole(null, "ROLE_USER")).toBeFalsy();
       expect(hasRole({}, "ROLE_USER")).toBeFalsy();
-      expect(hasRole({ currentUser: null }, "ROLE_USER")).toBeFalsy();
-      expect(hasRole({ currentUser: { data: null } }, "ROLE_USER")).toBeFalsy();
+      expect(hasRole({ data: null }, "ROLE_USER")).toBeFalsy();
+      expect(hasRole({ data: { root: null } }, "ROLE_USER")).toBeFalsy();
       expect(
-        hasRole({ currentUser: { data: { root: null } } }, "ROLE_USER"),
+        hasRole({ data: { root: { rolesList: null } } }, "ROLE_USER"),
       ).toBeFalsy();
       expect(
-        hasRole(
-          { currentUser: { data: { root: { rolesList: null } } } },
-          "ROLE_USER",
-        ),
-      ).toBeFalsy();
-      expect(
-        hasRole(
-          { currentUser: { data: { root: { rolesList: [] } } } },
-          "ROLE_USER",
-        ),
+        hasRole({ data: { root: { rolesList: [] } } }, "ROLE_USER"),
       ).toBeFalsy();
     });
+    expect(hasRole({ root: { rolesList: null } })).toBeFalsy();
   });
 });


### PR DESCRIPTION
In this PR, we fix the OptionalChaining mutation that caused a test failure on main. 

This involves a slight modification to the currentUser tests in the frontend (how we access the user roles in the "hasRole falls back correctly with various data missing" test).