### PR TITLE
Killing Mutations in CurrentUser.js

### DIFF
--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -226,20 +226,19 @@ describe("utils/currentUser tests", () => {
     test("hasRole falls back correctly with various data missing", async () => {
       expect(hasRole(null, "ROLE_USER")).toBeFalsy();
       expect(hasRole({}, "ROLE_USER")).toBeFalsy();
-      expect(hasRole({ currentUser: null }, "ROLE_USER")).toBeFalsy();
-      expect(hasRole({ currentUser: { data: null } }, "ROLE_USER")).toBeFalsy();
+      expect(hasRole({ data: null } , "ROLE_USER")).toBeFalsy();
       expect(
-        hasRole({ currentUser: { data: { root: null } } }, "ROLE_USER"),
+        hasRole({ data: { root: null } }, "ROLE_USER"),
       ).toBeFalsy();
       expect(
         hasRole(
-          { currentUser: { data: { root: { rolesList: null } } } },
+          { data: { root: { rolesList: null } } },
           "ROLE_USER",
         ),
       ).toBeFalsy();
       expect(
         hasRole(
-          { currentUser: { data: { root: { rolesList: [] } } } },
+           { data: { root: { rolesList: [] } } },
           "ROLE_USER",
         ),
       ).toBeFalsy();

--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -243,5 +243,8 @@ describe("utils/currentUser tests", () => {
         ),
       ).toBeFalsy();
     });
+      expect(
+          hasRole({root: {rolesList: null}})
+      ).toBeFalsy();
   });
 });

--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -226,25 +226,15 @@ describe("utils/currentUser tests", () => {
     test("hasRole falls back correctly with various data missing", async () => {
       expect(hasRole(null, "ROLE_USER")).toBeFalsy();
       expect(hasRole({}, "ROLE_USER")).toBeFalsy();
-      expect(hasRole({ data: null } , "ROLE_USER")).toBeFalsy();
+      expect(hasRole({ data: null }, "ROLE_USER")).toBeFalsy();
+      expect(hasRole({ data: { root: null } }, "ROLE_USER")).toBeFalsy();
       expect(
-        hasRole({ data: { root: null } }, "ROLE_USER"),
+        hasRole({ data: { root: { rolesList: null } } }, "ROLE_USER"),
       ).toBeFalsy();
       expect(
-        hasRole(
-          { data: { root: { rolesList: null } } },
-          "ROLE_USER",
-        ),
-      ).toBeFalsy();
-      expect(
-        hasRole(
-           { data: { root: { rolesList: [] } } },
-          "ROLE_USER",
-        ),
+        hasRole({ data: { root: { rolesList: [] } } }, "ROLE_USER"),
       ).toBeFalsy();
     });
-      expect(
-          hasRole({root: {rolesList: null}})
-      ).toBeFalsy();
+    expect(hasRole({ root: { rolesList: null } })).toBeFalsy();
   });
 });


### PR DESCRIPTION
In this PR, I kill the OptionalChaining mutations that are present in `currentUser.js`. Stryker describes it as the following:
![image](https://github.com/user-attachments/assets/f18da51d-bc32-44b3-9824-0a812358b83f)

As a result, I refactor some of the currentUser tests to ensure that it is correctly killed at every level.

These PRs are cherry-picked from proj-dining- that PR is available [here](https://github.com/ucsb-cs156/proj-dining/pull/15)