### PR TITLE
pc - update home page and add tests for logged out, logged in, and logged in as admin

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/config/OpenAPIConfig.java
+++ b/src/main/java/edu/ucsb/cs156/example/config/OpenAPIConfig.java
@@ -14,6 +14,8 @@ import io.swagger.v3.oas.annotations.servers.Server;
   description = """
     <p><a href='/'>Home Page</a></p>
     <p><a href='/h2-console'>H2 Console (only on localhost)</a></p>
+    <p><a href='/login'>login</a></p>
+    <p><a href='/logout'>logout</a></p>
     """     
     ),
   servers = @Server(url = "/")

--- a/src/main/java/edu/ucsb/cs156/example/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/example/config/SecurityConfig.java
@@ -11,6 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -144,6 +146,13 @@ public class SecurityConfig {
     }
     Optional<User> u = userRepository.findByEmail(email);
     return u.isPresent() && u.get().getAdmin();
+  }
+
+  @Bean
+  static RoleHierarchy roleHierarchy() {
+    return RoleHierarchyImpl.withDefaultRolePrefix()
+            .role("ADMIN").implies("USER")
+            .build();
   }
 }
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HomepageController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HomepageController.java
@@ -1,21 +1,51 @@
 package edu.ucsb.cs156.example.controllers;
 
-
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.example.services.CurrentUserService;
+
 @RestController
 public class HomepageController {
-    @GetMapping("/")
-    public String index(){
-        return """
-                <p>This is the homepage for team01 which is simply a backend with no frontend.</p>
-                <p><ul>
-                  <li><a href="/oauth2/authorization/google">To sign in, click here</a></li>
-                  <li><a href="/logout">To sign out, click here</a></li>
-                  <li><a href="/swagger-ui/index.html">Click here to go to Swagger</a></li>
-                </ul></p>
-                """;
+
+  @Autowired
+  CurrentUserService currentUserService;
+
+  @GetMapping("/")
+  public String index() {
+    String HomePageHTMLTemplate = """
+        <p>This is the homepage for team01 which is simply a backend with no frontend.</p>
+        <p>
+          <ul>
+            %s
+            %s
+            %s
+            <li><a href="/swagger-ui/index.html">Swagger API Links</a></li>
+            <li><a href="/h2-console">H2 console (only on localhost)</a></li>
+          </ul>
+        </p>
+        """;
+    return String.format(HomePageHTMLTemplate, getLoggedInAs(), getLoginLogoutLink(), getRoles());
+  }
+
+  private String getLoginLogoutLink() {
+
+    return currentUserService.isLoggedIn() ?
+      """ 
+      <li><a href="/logout">Logout</a></li>""" :
+      """
+      <li><a href="/oauth2/authorization/google">Login</a></li>""" ;
     }
+
+  private String getLoggedInAs() {
+    return currentUserService.isLoggedIn()
+        ? String.format("<li>Currently logged in as %s</li>", currentUserService.getUser().getEmail())
+        : "<li>Not logged in</li>";
+  }
+
+  private String getRoles() {
+    return String.format("<li>Roles: %s</li>", currentUserService.getRolesSorted());
+  }
 
 }

--- a/src/main/java/edu/ucsb/cs156/example/services/CurrentUserService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/CurrentUserService.java
@@ -4,42 +4,62 @@ import edu.ucsb.cs156.example.entities.User;
 import edu.ucsb.cs156.example.models.CurrentUser;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.springframework.security.core.GrantedAuthority;
 
 /**
  * This is a service that provides information about the current user.
  *
- * It is an abstract class because we have different implementations for testing and production.
+ * It is an abstract class because we have different implementations for testing
+ * and production.
  * 
  */
 public abstract class CurrentUserService {
 
   /**
    * This method returns the current user as a User object.
+   * 
    * @return the current user
    */
   public abstract User getUser();
 
   /**
    * This method returns the current user as a CurrentUser object
+   * 
    * @return the current user
    */
   public abstract CurrentUser getCurrentUser();
 
   /**
    * This method returns the roles of the current user.
+   * 
    * @return a collection of roles
    */
   public abstract Collection<? extends GrantedAuthority> getRoles();
 
   /**
    * This method returns whether the current user is logged in.
+   * 
    * @return whether the current user is logged in
    */
-  
+
   public final boolean isLoggedIn() {
     return getUser() != null;
   }
 
+
+  /**
+   * This method returns the roles of the current user as a sorted list of strings.
+   * 
+   * @return a collection of roles
+   */
+  public  List<String> getRolesSorted() {
+    Collection<? extends GrantedAuthority> authorities = getRoles();
+    List<String> roles = authorities.stream()
+        .map(GrantedAuthority::getAuthority)
+        .sorted()
+        .toList();
+    return roles;
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HomepageControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HomepageControllerTests.java
@@ -1,37 +1,83 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.ControllerTestCase;
-import edu.ucsb.cs156.example.repositories.UserRepository;
-import edu.ucsb.cs156.example.testconfig.TestConfig;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.web.servlet.MvcResult;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
 
 @WebMvcTest(controllers = HomepageController.class)
 @Import(TestConfig.class)
 public class HomepageControllerTests extends ControllerTestCase {
 
-    @MockBean
-    UserRepository userRepository;
+  @MockitoBean
+  UserRepository userRepository;
 
-    @Test
-    public void homepage_returns_successfully() throws Exception {
-        String expectedResponse = """
-                <p>This is the homepage for team01 which is simply a backend with no frontend.</p>
-                <p><ul>
-                  <li><a href="/oauth2/authorization/google">To sign in, click here</a></li>
-                  <li><a href="/logout">To sign out, click here</a></li>
-                  <li><a href="/swagger-ui/index.html">Click here to go to Swagger</a></li>
-                </ul></p>
-                """;
-        MvcResult response = mockMvc.perform(get("/")).andExpect(status().isOk()).andReturn();
-        assertEquals(expectedResponse, response.getResponse().getContentAsString());
-    }
+  @Test
+  public void test_homepage_not_logged_in() throws Exception {
+    String expectedResponse = """
+        <p>This is the homepage for team01 which is simply a backend with no frontend.</p>
+        <p>
+          <ul>
+            <li>Not logged in</li>
+            <li><a href="/oauth2/authorization/google">Login</a></li>
+            <li>Roles: [ROLE_ANONYMOUS]</li>
+            <li><a href="/swagger-ui/index.html">Swagger API Links</a></li>
+            <li><a href="/h2-console">H2 console (only on localhost)</a></li>
+          </ul>
+        </p>
+        """;
+
+    MvcResult response = mockMvc.perform(get("/")).andExpect(status().isOk()).andReturn();
+    assertEquals(expectedResponse, response.getResponse().getContentAsString());
+  }
+
+  @Test
+  @WithMockUser(roles = { "USER" })
+  public void test_homepage_logged_in() throws Exception {
+    String expectedResponse = """
+        <p>This is the homepage for team01 which is simply a backend with no frontend.</p>
+        <p>
+          <ul>
+            <li>Currently logged in as user@example.org</li>
+            <li><a href="/logout">Logout</a></li>
+            <li>Roles: [ROLE_USER]</li>
+            <li><a href="/swagger-ui/index.html">Swagger API Links</a></li>
+            <li><a href="/h2-console">H2 console (only on localhost)</a></li>
+          </ul>
+        </p>
+        """;
+
+    MvcResult response = mockMvc.perform(get("/")).andExpect(status().isOk()).andReturn();
+    assertEquals(expectedResponse, response.getResponse().getContentAsString());
+  }
+
+  @Test
+  @WithMockUser(roles = { "ADMIN" }, username="foo")
+  public void test_homepage_admin_logged_in() throws Exception {
+    String expectedResponse = """
+        <p>This is the homepage for team01 which is simply a backend with no frontend.</p>
+        <p>
+          <ul>
+            <li>Currently logged in as foo@example.org</li>
+            <li><a href="/logout">Logout</a></li>
+            <li>Roles: [ROLE_ADMIN]</li>
+            <li><a href="/swagger-ui/index.html">Swagger API Links</a></li>
+            <li><a href="/h2-console">H2 console (only on localhost)</a></li>
+          </ul>
+        </p>
+        """;
+
+    MvcResult response = mockMvc.perform(get("/")).andExpect(status().isOk()).andReturn();
+    assertEquals(expectedResponse, response.getResponse().getContentAsString());
+  }
 }


### PR DESCRIPTION
In this PR, we improve the home page, and also illustrate how to write tests for the condition of being:
* Not logged in
* Logged in as a regular user
* Logged in as an admin

We also add that ROLE_ADMIN implies ROLE_USER.

## Before: 

<img width="723" alt="image" src="https://github.com/user-attachments/assets/1d1284b7-8f56-4b7a-8372-6a113036bf6f" />

## After:

Logged out:

<img width="656" alt="image" src="https://github.com/user-attachments/assets/e8ef7f60-8bba-44df-9fe2-80ffcbf2938c" />

Logged in (as admin, phtcon@ucsb.edu):
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/8c404ef0-8a3e-4a19-9e8c-5efed18b1eaa" />

Logged in as non admin, not ucsb user:
<img width="1315" alt="image" src="https://github.com/user-attachments/assets/ff18031e-3958-455f-a398-c67c2aa0c09e" />

# Changes to Swagger

We also add a login and logout link to the Swagger Page:

Before:
<img width="345" alt="image" src="https://github.com/user-attachments/assets/55e83488-5379-45a9-a49c-431135c7896b" />


After: 

<img width="885" alt="image" src="https://github.com/user-attachments/assets/112a9bc4-c56d-488b-830a-b344b17a3824" />



