### PR TITLE
pc - cleaner dokku build logs 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN curl --version
 
 COPY . /home/app
 
+ENV PRODUCTION=true
+ENV NPM_CONFIG_LOGLEVEL=error
 RUN mvn \
    -B \
    -ntp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,13 @@ RUN curl --version
 
 COPY . /home/app
 
-RUN mvn -B -Pproduction -DskipTests -f /home/app/pom.xml clean package
+RUN mvn \
+   -B \
+   -ntp \
+   -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+   -DskipTests \
+   -Pproduction \
+   -f /home/app/pom.xml clean package
 
 RUN ["chmod", "+x", "/home/app/startup.sh"]
 ENTRYPOINT ["/home/app/startup.sh","/home/app/target/team01-1.0.0.jar"]


### PR DESCRIPTION
In this PR, we make two changes to the Dockerfile used for dokku installs **so that it is much easier to find errors in the build logs**.

Each of these changes makes the build logs cleaner by getting rid of many lines of output that don't add much value, but make it hard to find significant error messages.

First, we add these flags to the `mvn package` step:

```
  -ntp \
   -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
 ```

Second we add this environment variable:
```
ENV NPM_CONFIG_LOGLEVEL=error
```

## Explanation:

`-ntp` hides the progress bars for downloading dependencies.

The next  flag sets the log level to `warn` for the `Slf4jMavenTransferListener` which is the providing output when Maven downloads dependencies:

* ` -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \`

That output looks like this, and typically doesn't provide much useful information:

```
#17 1.739 [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-parent/3.3.4/spring-boot-starter-parent-3.3.4.pom
#17 1.980 [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-parent/3.3.4/spring-boot-starter-parent-3.3.4.pom (13 kB at 55 kB/s)
#17 1.996 [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/3.3.4/spring-boot-dependencies-3.3.4.pom
... (many dozens of lines omitted)
```

The environment variable `ENV NPM_CONFIG_LOGLEVEL=error` sets the error output level for `npm`.

This will  suppress all npm warnings, including potentially useful deprecation notices; but we are still typically seeing those when we develop on `localhost`.   On dokku, these are just typically clutter that makes it more difficult to find build errors.


